### PR TITLE
fix: bug(math): intermediate overflow on large factorial ratios

### DIFF
--- a/src/mcp-server/tools/definitions/calculate.tool.ts
+++ b/src/mcp-server/tools/definitions/calculate.tool.ts
@@ -6,7 +6,7 @@
 
 import { tool, z } from '@cyanheads/mcp-ts-core';
 import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
-import { getMathService } from '@/services/math/math-service.js';
+import { getMathService, type NumericType } from '@/services/math/math-service.js';
 
 export const calculateTool = tool('calculate', {
   description:
@@ -59,6 +59,13 @@ export const calculateTool = tool('calculate', {
       .optional()
       .describe(
         'Significant digits (1–16) for numeric results. Omit for full precision. Empty string is treated as omitted. Ignored for symbolic operations (simplify, derivative).',
+      ),
+    numericType: z
+      .enum(['number', 'BigNumber', 'Fraction'])
+      .default('number')
+      .optional()
+      .describe(
+        'Numeric type for evaluation. "number" (default) uses 64-bit floats — fast, sufficient for most calculations. "BigNumber" uses arbitrary-precision arithmetic — use when an expression overflows to Infinity or NaN (e.g. very large exponents or factorials). "Fraction" uses exact rational arithmetic — use for precise fractional results without floating-point rounding. Ignored for symbolic operations (simplify, derivative).',
       ),
   }),
   output: z.object({
@@ -144,11 +151,12 @@ export const calculateTool = tool('calculate', {
     const { expression, operation, scope } = input;
     const variable = input.variable || undefined;
     const precision = typeof input.precision === 'number' ? input.precision : undefined;
+    const numericType = (input.numericType ?? 'number') as NumericType;
 
     switch (operation) {
       case 'evaluate':
-        ctx.log.info('Evaluated expression', { expression });
-        return { ...math.evaluateExpression(expression, ctx, scope, precision), expression };
+        ctx.log.info('Evaluated expression', { expression, numericType });
+        return { ...math.evaluateExpression(expression, ctx, scope, precision, numericType), expression };
       case 'simplify':
         ctx.log.info('Simplified expression', { expression });
         return { ...math.simplifyExpression(expression, ctx), expression };

--- a/src/services/math/math-service.ts
+++ b/src/services/math/math-service.ts
@@ -108,6 +108,57 @@ const BLOCKED_SCOPE_KEYS = new Set([
 ]);
 
 /**
+ * Rewrite integer factorial ratios (n! / m!, n ≥ m) to permutations(n, n-m).
+ * math.js permutations() computes the product n*(n-1)*...*(m+1) directly,
+ * avoiding the intermediate factorial that would overflow to Infinity.
+ * Only matches bare integer literals — symbolic expressions are left unchanged.
+ */
+function simplifyFactorialRatios(expr: string): string {
+  return expr.replace(/\b(\d+)!\s*\/\s*(\d+)!/g, (match, a, b) => {
+    const n = Number(a);
+    const m = Number(b);
+    if (n >= m) return `permutations(${n}, ${n - m})`;
+    return match;
+  });
+}
+
+/** Numeric type for math.js instance creation. */
+export type NumericType = 'number' | 'BigNumber' | 'Fraction';
+
+interface HardenedMathHandles {
+  evaluate: (expr: string, scope?: Record<string, number>) => unknown;
+  format: (value: unknown, options?: { precision?: number; lowerExp?: number; upperExp?: number }) => string;
+  typeOf: (value: unknown) => string;
+}
+
+/**
+ * Creates a security-hardened math.js instance with a specific numeric type.
+ * Extracted so BigNumber and Fraction instances share the same restrictions.
+ */
+function createHardenedMath(numberType: NumericType = 'number'): HardenedMathHandles {
+  // biome-ignore lint/style/noNonNullAssertion: math.js types declare `all` as potentially undefined, but it's always defined at runtime
+  const math = create(all!, { number: numberType });
+
+  math.createUnit(CUSTOM_UNITS);
+  math.import({ average: math.mean, avg: math.mean });
+
+  const disabled: Record<string, unknown> = {};
+  for (const fn of DISABLED_FUNCTIONS) {
+    disabled[fn] = () => { throw new Error(`Function "${fn}" is disabled for security.`); };
+  }
+  for (const [key, value] of Object.entries(REDACTED_CONSTANTS)) {
+    disabled[key] = value;
+  }
+  math.import(disabled, { override: true });
+
+  return {
+    evaluate: math.evaluate.bind(math),
+    format: math.format.bind(math),
+    typeOf: math.typeOf.bind(math),
+  };
+}
+
+/**
  * Check for expression separators outside square brackets.
  * Semicolons inside `[...]` are valid matrix row separators.
  * Newlines (`\n`, `\r`) are also expression separators in math.js.
@@ -125,59 +176,73 @@ function hasExpressionSeparator(expr: string): boolean {
 
 export class MathService {
   private readonly evaluate: (expr: string, scope?: Record<string, number>) => unknown;
+  private readonly evaluateBigNumber: (expr: string, scope?: Record<string, number>) => unknown;
+  private readonly evaluateFraction: (expr: string, scope?: Record<string, number>) => unknown;
   private readonly simplify: (expr: string, rules?: SimplifyRule[]) => { toString(): string };
   private readonly derivative: (expr: string, variable: string) => { toString(): string };
   private readonly simplifyRules: SimplifyRule[];
-  private readonly format: (
-    value: unknown,
-    options?: { precision?: number; lowerExp?: number; upperExp?: number },
-  ) => string;
+  private readonly format: (value: unknown, options?: { precision?: number; lowerExp?: number; upperExp?: number }) => string;
+  private readonly formatBigNumber: (value: unknown, options?: { precision?: number; lowerExp?: number; upperExp?: number }) => string;
+  private readonly formatFraction: (value: unknown, options?: { precision?: number; lowerExp?: number; upperExp?: number }) => string;
   private readonly typeOf: (value: unknown) => string;
+  private readonly typeOfBigNumber: (value: unknown) => string;
+  private readonly typeOfFraction: (value: unknown) => string;
   private readonly config: ServerConfig;
 
   constructor(config: ServerConfig) {
     this.config = config;
+
+    // Default 'number' instance (64-bit float) — used for all standard evaluations
+    const defaultMath = createHardenedMath('number');
+    this.evaluate = defaultMath.evaluate;
+    this.format = defaultMath.format;
+    this.typeOf = defaultMath.typeOf;
+
+    // Opt-in BigNumber instance — arbitrary precision, no overflow on large factorials
+    const bigNumberMath = createHardenedMath('BigNumber');
+    this.evaluateBigNumber = bigNumberMath.evaluate;
+    this.formatBigNumber = bigNumberMath.format;
+    this.typeOfBigNumber = bigNumberMath.typeOf;
+
+    // Opt-in Fraction instance — exact rational arithmetic
+    const fractionMath = createHardenedMath('Fraction');
+    this.evaluateFraction = fractionMath.evaluate;
+    this.formatFraction = fractionMath.format;
+    this.typeOfFraction = fractionMath.typeOf;
+
     // biome-ignore lint/style/noNonNullAssertion: math.js types declare `all` as potentially undefined, but it's always defined at runtime
     const math = create(all!);
-
-    // Save references before overriding — these bypass the expression scope restrictions
-    this.evaluate = math.evaluate.bind(math);
     this.simplify = math.simplify.bind(math);
     this.derivative = math.derivative.bind(math);
     this.simplifyRules = [...math.simplify.rules, ...TRIG_SIMPLIFY_RULES];
-    this.format = math.format.bind(math);
-    this.typeOf = math.typeOf.bind(math);
-
-    // Register custom units and natural-language function aliases.
-    // Must run before createUnit/import are disabled below.
-    math.createUnit(CUSTOM_UNITS);
-    math.import({ average: math.mean, avg: math.mean });
-
-    // Disable dangerous functions in expression scope
-    const disabled: Record<string, unknown> = {};
-    for (const fn of DISABLED_FUNCTIONS) {
-      disabled[fn] = () => {
-        throw new Error(`Function "${fn}" is disabled for security.`);
-      };
-    }
-    // Redact constants that leak implementation details
-    for (const [key, value] of Object.entries(REDACTED_CONSTANTS)) {
-      disabled[key] = value;
-    }
-    math.import(disabled, { override: true });
   }
 
-  /** Evaluate a math expression with optional variable scope and precision. */
+  /** Evaluate a math expression with optional variable scope, precision, and numeric type. */
   evaluateExpression(
     expression: string,
     ctx: Context,
     scope?: Record<string, number>,
     precision?: number,
+    numericType: NumericType = 'number',
   ): MathResult {
+    // Pre-simplify bare factorial ratios (e.g. 10000!/9999! → permutations(10000,1))
+    // before evaluation to avoid intermediate overflow even in 'number' mode.
+    expression = simplifyFactorialRatios(expression);
     this.validateInput(expression, ctx);
     if (scope) this.validateScope(scope, ctx);
+
+    const evalFn = numericType === 'BigNumber' ? this.evaluateBigNumber
+                 : numericType === 'Fraction'  ? this.evaluateFraction
+                 : this.evaluate;
+    const formatFn = numericType === 'BigNumber' ? this.formatBigNumber
+                   : numericType === 'Fraction'  ? this.formatFraction
+                   : this.format;
+    const typeOfFn = numericType === 'BigNumber' ? this.typeOfBigNumber
+                   : numericType === 'Fraction'  ? this.typeOfFraction
+                   : this.typeOf;
+
     const raw = this.runWithTimeout(
-      () => (scope ? this.evaluate(expression, scope) : this.evaluate(expression)),
+      () => (scope ? evalFn(expression, scope) : evalFn(expression)),
       ctx,
     );
     if (typeof raw === 'number' && !Number.isFinite(raw)) {
@@ -186,11 +251,11 @@ export class MathService {
         { reason: 'undefined_result', ...ctx.recoveryFor('undefined_result') },
       );
     }
-    const resultType = this.typeOf(raw);
+    const resultType = typeOfFn(raw);
     this.validateResultType(resultType, ctx);
     // Match JS Number.toString thresholds — math.js defaults to exp ≥ 5,
     // which would render 83810205 as "8.3810205e+7".
-    const result = this.format(raw, {
+    const result = formatFn(raw, {
       lowerExp: -6,
       upperExp: 21,
       ...(precision != null && { precision }),

--- a/tests/mcp-server/tools/definitions/calculate.tool.test.ts
+++ b/tests/mcp-server/tools/definitions/calculate.tool.test.ts
@@ -346,4 +346,68 @@ describe('calculate tool', () => {
       );
     });
   });
+
+  describe('factorial overflow — issue #7', () => {
+    it('evaluates 10000!/9999! correctly via pre-simplification (no overflow)', async () => {
+      // Without the fix, 10000! overflows to Infinity and Infinity/Infinity = NaN.
+      const result = await call({ expression: '10000! / 9999!' });
+      expect(result.result).toBe('10000');
+      expect(result.resultType).toBe('number');
+    });
+
+    it('evaluates 100!/98! (= 100 * 99 = 9900) correctly', async () => {
+      const result = await call({ expression: '100! / 98!' });
+      expect(result.result).toBe('9900');
+    });
+
+    it('handles equal factorials (n!/n! = 1)', async () => {
+      const result = await call({ expression: '5! / 5!' });
+      expect(result.result).toBe('1');
+    });
+
+    it('handles small factorials normally (no pre-simplification needed)', async () => {
+      const result = await call({ expression: '5! / 2!' });
+      expect(result.result).toBe('60');
+    });
+  });
+
+  describe('numericType parameter', () => {
+    it('defaults to number type', async () => {
+      const result = await call({ expression: '2 + 2' });
+      expect(result.resultType).toBe('number');
+    });
+
+    it('BigNumber: evaluates with arbitrary precision', async () => {
+      const result = await call({ expression: '0.1 + 0.2', numericType: 'BigNumber' });
+      expect(result.resultType).toBe('BigNumber');
+      expect(result.result).toBe('0.3');
+    });
+
+    it('BigNumber: handles very large exponents without overflow', async () => {
+      const result = await call({ expression: '2^1000', numericType: 'BigNumber' });
+      expect(result.resultType).toBe('BigNumber');
+      expect(result.result).toMatch(/^1\.071509/);
+    });
+
+    it('Fraction: evaluates with exact rational arithmetic', async () => {
+      const result = await call({ expression: '1/3 + 1/6', numericType: 'Fraction' });
+      expect(result.resultType).toBe('Fraction');
+      expect(result.result).toBe('1/2');
+    });
+
+    it('Fraction: 0.1 + 0.2 is exactly 3/10', async () => {
+      const result = await call({ expression: '0.1 + 0.2', numericType: 'Fraction' });
+      expect(result.resultType).toBe('Fraction');
+      expect(result.result).toBe('3/10');
+    });
+
+    it('numericType is ignored for simplify operation', async () => {
+      const result = await call({
+        expression: '2x + 3x',
+        operation: 'simplify',
+        numericType: 'BigNumber',
+      });
+      expect(result.resultType).toBe('string');
+    });
+  });
 });


### PR DESCRIPTION
/claim #7

Resolves https://github.com/cyanheads/calculator-mcp-server/issues/7

## What

Two complementary fixes for the factorial overflow bug:

**1. Pre-simplification of integer factorial ratios** (works in default `number` mode)

Bare expressions like `n! / m!` are rewritten to `permutations(n, n-m)` before evaluation. `permutations()` computes the product `n*(n-1)*...*(m+1)` directly — no intermediate `n!` is ever materialized, so `10000! / 9999!` correctly returns `10000` without overflow.

**2. Opt-in `numericType` parameter** (your preferred Option 2)

Adds `numericType: 'number' | 'BigNumber' | 'Fraction'` to the `calculate` tool input:
- `'number'` (default) — 64-bit float, no perf impact, unchanged semantics
- `'BigNumber'` — arbitrary-precision arithmetic for overflow-prone expressions
- `'Fraction'` — exact rational arithmetic (`1/3 + 1/6 → 1/2`)

Each type gets its own hardened math.js instance (same security restrictions) created at startup — no per-call overhead for the default path.

## Why

`10000!` overflows to `Infinity` as a 64-bit float; `Infinity / Infinity = NaN`. The pre-simplification handles the reported pattern without touching the default numeric type. The `numericType` parameter lets LLMs explicitly escalate when they anticipate overflow, following your proposed Option 2 exactly.

## Tests added

- Factorial overflow cases (`10000!/9999!`, `100!/98!`, edge cases `n!/n!`)
- All three `numericType` variants with expected result types
- Confirms `numericType` is ignored for symbolic operations
